### PR TITLE
Add orchestration demo MVC frontend

### DIFF
--- a/CatelogService.sln
+++ b/CatelogService.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35707.178 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatelogService", "CatelogService.csproj", "{929E7F03-79B5-4CDB-A5AD-65874499A43B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrchestrationDemo", "OrchestrationDemo\\OrchestrationDemo.csproj", "{A6F79961-49F8-488F-9146-4826F8350417}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,11 +14,16 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{929E7F03-79B5-4CDB-A5AD-65874499A43B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{929E7F03-79B5-4CDB-A5AD-65874499A43B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{929E7F03-79B5-4CDB-A5AD-65874499A43B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{929E7F03-79B5-4CDB-A5AD-65874499A43B}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+                {929E7F03-79B5-4CDB-A5AD-65874499A43B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {929E7F03-79B5-4CDB-A5AD-65874499A43B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {929E7F03-79B5-4CDB-A5AD-65874499A43B}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A6F79961-49F8-488F-9146-4826F8350417}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A6F79961-49F8-488F-9146-4826F8350417}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A6F79961-49F8-488F-9146-4826F8350417}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A6F79961-49F8-488F-9146-4826F8350417}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+                StartupProject = OrchestrationDemo
+        EndGlobalSection
 EndGlobal

--- a/OrchestrationDemo/Controllers/WorkflowController.cs
+++ b/OrchestrationDemo/Controllers/WorkflowController.cs
@@ -1,8 +1,8 @@
 using CatelogService.Model.Data;
-using CatelogService.ViewModels;
 using Microsoft.AspNetCore.Mvc;
+using OrchestrationDemo.ViewModels;
 
-namespace CatelogService.Controllers
+namespace OrchestrationDemo.Controllers
 {
     public class WorkflowController : Controller
     {

--- a/OrchestrationDemo/OrchestrationDemo.csproj
+++ b/OrchestrationDemo/OrchestrationDemo.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../CatelogService.csproj" />
+  </ItemGroup>
+</Project>

--- a/OrchestrationDemo/Program.cs
+++ b/OrchestrationDemo/Program.cs
@@ -1,0 +1,24 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllersWithViews();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Workflow/Index");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapControllerRoute(
+    name: "default",
+    pattern: "{controller=Workflow}/{action=Index}/{id?}");
+
+app.Run();

--- a/OrchestrationDemo/Properties/launchSettings.json
+++ b/OrchestrationDemo/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "OrchestrationDemo": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7186;http://localhost:5186",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/OrchestrationDemo/ViewModels/WorkflowViewModel.cs
+++ b/OrchestrationDemo/ViewModels/WorkflowViewModel.cs
@@ -1,6 +1,6 @@
 using CatelogService.Model.Data;
 
-namespace CatelogService.ViewModels
+namespace OrchestrationDemo.ViewModels
 {
     public class WorkflowViewModel
     {

--- a/OrchestrationDemo/Views/Shared/_Layout.cshtml
+++ b/OrchestrationDemo/Views/Shared/_Layout.cshtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - Orchestration Demo</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="~/css/site.css" />
+</head>
+<body>
+    <header class="bg-dark text-white py-3 mb-4">
+        <div class="container">
+            <h1 class="h3 mb-0">Order Orchestration Demo</h1>
+            <p class="mb-0">Explore the state transitions of the order workflow.</p>
+        </div>
+    </header>
+    <main class="container mb-5">
+        @RenderBody()
+    </main>
+    <footer class="bg-light py-3">
+        <div class="container">
+            <span class="text-muted">&copy; @DateTime.UtcNow.Year Orchestration Demo</span>
+        </div>
+    </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="~/js/site.js"></script>
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/OrchestrationDemo/Views/Workflow/Index.cshtml
+++ b/OrchestrationDemo/Views/Workflow/Index.cshtml
@@ -1,5 +1,6 @@
-@model WorkflowViewModel
+@model OrchestrationDemo.ViewModels.WorkflowViewModel
 @using System.Text.Json
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 
 @{
     ViewData["Title"] = "Order Orchestration";
@@ -9,7 +10,7 @@
 <h1>Order Orchestration</h1>
 <p>Select the starting state to execute the orchestration workflow. Each step returns a payload describing what happened and the next state that will be executed.</p>
 
-<form asp-action="Run" method="post">
+<form asp-action="Run" method="post" class="workflow-form">
     @Html.AntiForgeryToken()
     <div class="form-row">
         <label asp-for="SelectedState">Start from state</label>
@@ -21,7 +22,7 @@
 @if (Model.Steps?.Any() == true)
 {
     <h2>Execution results</h2>
-    <table>
+    <table class="table table-striped">
         <thead>
             <tr>
                 <th>State</th>

--- a/OrchestrationDemo/Views/_ViewImports.cshtml
+++ b/OrchestrationDemo/Views/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+@using OrchestrationDemo
+@using OrchestrationDemo.ViewModels
+@using Microsoft.AspNetCore.Mvc.Rendering
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/OrchestrationDemo/Views/_ViewStart.cshtml
+++ b/OrchestrationDemo/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/OrchestrationDemo/appsettings.Development.json
+++ b/OrchestrationDemo/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/OrchestrationDemo/appsettings.json
+++ b/OrchestrationDemo/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/OrchestrationDemo/wwwroot/css/site.css
+++ b/OrchestrationDemo/wwwroot/css/site.css
@@ -1,0 +1,23 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: #f8f9fa;
+}
+
+.workflow-form {
+    margin-bottom: 1.5rem;
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.workflow-form select {
+    min-width: 220px;
+}
+
+pre {
+    white-space: pre-wrap;
+    background-color: #f1f3f5;
+    border-radius: 0.25rem;
+    padding: 0.75rem;
+    margin-bottom: 0;
+}

--- a/OrchestrationDemo/wwwroot/js/site.js
+++ b/OrchestrationDemo/wwwroot/js/site.js
@@ -1,0 +1,1 @@
+// Reserved for future client-side enhancements to the orchestration demo experience.


### PR DESCRIPTION
## Summary
- create a new OrchestrationDemo MVC app that references the existing orchestration workflow commands
- move the workflow controller, view, and supporting assets into the MVC project with a simple layout and styling
- update the solution file so the MVC app is the startup project alongside the existing service

## Testing
- dotnet build CatelogService.sln *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c40b15c8328bc2a3048381a3367