### PR TITLE
Remove invalid Razor view-model import

### DIFF
--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,3 +1,2 @@
-@using CatelogService.ViewModels
 @using Microsoft.AspNetCore.Mvc.Rendering
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
## Summary
- remove the stale `CatelogService.ViewModels` namespace import from the root `_ViewImports` file to stop Razor from referencing a non-existent namespace

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc340e8e10832896fa73e573736cb6