### PR TITLE
Define distinct workflow routes for UI and API

### DIFF
--- a/Controllers/WorkflowController.cs
+++ b/Controllers/WorkflowController.cs
@@ -1,0 +1,51 @@
+using CatelogService.Model.Data;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CatelogService.Controllers
+{
+    [ApiController]
+    [Route("api/catalog/workflow")]
+    public class WorkflowController : ControllerBase
+    {
+        private readonly CommandInvoker _commandInvoker = new();
+
+        [HttpGet("")]
+        public ActionResult<WorkflowOverviewResponse> Index()
+        {
+            var availableStates = Enum.GetNames(typeof(OrcState));
+
+            return Ok(new WorkflowOverviewResponse
+            {
+                AvailableStates = availableStates,
+                DefaultState = OrcState.ProductCatalogShow.ToString(),
+                RunWorkflowEndpoint = Url?.RouteUrl(
+                    routeName: "CatalogWorkflowRun",
+                    values: new { state = OrcState.ProductCatalogShow })
+            });
+        }
+
+        [HttpGet("run/{state?}", Name = "CatalogWorkflowRun")]
+        public ActionResult<IReadOnlyList<CommandResult>> Run(string? state = null)
+        {
+            var targetState = OrcState.ProductCatalogShow;
+
+            if (!string.IsNullOrWhiteSpace(state) &&
+                !Enum.TryParse(state, ignoreCase: true, out targetState))
+            {
+                return BadRequest($"Unknown state '{state}'.");
+            }
+
+            var results = _commandInvoker.RunWorkflow(targetState);
+            return Ok(results);
+        }
+
+        public record WorkflowOverviewResponse
+        {
+            public IEnumerable<string> AvailableStates { get; init; } = Array.Empty<string>();
+            public string DefaultState { get; init; } = string.Empty;
+            public string? RunWorkflowEndpoint { get; init; }
+            public string Description { get; init; } =
+                "Use the run endpoint to execute the catalog orchestration workflow.";
+        }
+    }
+}

--- a/OrchestrationDemo/Controllers/WorkflowController.cs
+++ b/OrchestrationDemo/Controllers/WorkflowController.cs
@@ -4,28 +4,30 @@ using OrchestrationDemo.ViewModels;
 
 namespace OrchestrationDemo.Controllers
 {
+    [Route("orchestration-demo/workflow")]
     public class WorkflowController : Controller
     {
+        private const string IndexViewName = "Index";
         private readonly CommandInvoker _commandInvoker = new();
 
-        [HttpGet]
+        [HttpGet("")]
         public IActionResult Index()
         {
             var model = new WorkflowViewModel
             {
                 AvailableStates = Enum.GetValues<OrcState>()
             };
-            return View(model);
+            return View(IndexViewName, model);
         }
 
-        [HttpPost]
+        [HttpPost("run")]
         [ValidateAntiForgeryToken]
         public IActionResult Run(WorkflowViewModel model)
         {
             var results = _commandInvoker.RunWorkflow(model.SelectedState);
             model.Steps = results;
             model.AvailableStates = Enum.GetValues<OrcState>();
-            return View("Index", model);
+            return View(IndexViewName, model);
         }
     }
 }

--- a/OrchestrationDemo/Program.cs
+++ b/OrchestrationDemo/Program.cs
@@ -6,7 +6,7 @@ var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
 {
-    app.UseExceptionHandler("/Workflow/Index");
+    app.UseExceptionHandler("/orchestration-demo/workflow");
     app.UseHsts();
 }
 
@@ -17,8 +17,11 @@ app.UseRouting();
 
 app.UseAuthorization();
 
-app.MapControllerRoute(
-    name: "default",
-    pattern: "{controller=Workflow}/{action=Index}/{id?}");
+app.MapControllers();
+app.MapGet("/", context =>
+{
+    context.Response.Redirect("/orchestration-demo/workflow");
+    return Task.CompletedTask;
+});
 
 app.Run();


### PR DESCRIPTION
## Summary
- add an attribute-routed workflow controller for the Catalog service with explicit index and run endpoints
- scope the orchestration demo workflow controller to a unique route and reuse the index view constant
- switch the orchestration demo startup to controller attribute routing and redirect the site root to the workflow page

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc5cd37d588328b3059d782cf24048