### PR TITLE
Add welcome page for orchestration demo

### DIFF
--- a/OrchestrationDemo/Controllers/HomeController.cs
+++ b/OrchestrationDemo/Controllers/HomeController.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace OrchestrationDemo.Controllers
+{
+    public class HomeController : Controller
+    {
+        [HttpGet]
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/OrchestrationDemo/Views/Home/Index.cshtml
+++ b/OrchestrationDemo/Views/Home/Index.cshtml
@@ -1,0 +1,49 @@
+@{
+    ViewData["Title"] = "Welcome";
+}
+
+<section class="text-center py-5">
+    <h1 class="display-5 fw-bold mb-3">Welcome to the Order Orchestration Demo</h1>
+    <p class="lead mb-4">
+        Explore how an order moves through the different stages of our orchestration workflow.
+        This guided experience shows the states, transitions, and payloads that power the process.
+    </p>
+    <a class="btn btn-primary btn-lg" asp-controller="Workflow" asp-action="Index">
+        View the workflow
+    </a>
+</section>
+
+<section class="row g-4 justify-content-center">
+    <article class="col-md-4">
+        <div class="card h-100 shadow-sm">
+            <div class="card-body">
+                <h2 class="h4">Interactive Execution</h2>
+                <p>Pick a starting state and run the workflow to see each command that gets executed.</p>
+            </div>
+        </div>
+    </article>
+    <article class="col-md-4">
+        <div class="card h-100 shadow-sm">
+            <div class="card-body">
+                <h2 class="h4">Detailed Payloads</h2>
+                <p>Inspect the payload returned by every step to understand what data moves through the system.</p>
+            </div>
+        </div>
+    </article>
+    <article class="col-md-4">
+        <div class="card h-100 shadow-sm">
+            <div class="card-body">
+                <h2 class="h4">State Transitions</h2>
+                <p>Follow the journey from the starting point to completion and learn how each step determines the next one.</p>
+            </div>
+        </div>
+    </article>
+</section>
+
+<section class="mt-5">
+    <h2 class="h4">Ready to dive in?</h2>
+    <p>
+        Use the button above to launch the workflow explorer. Once you are there you can re-run the process from any state
+        to experiment with different execution paths.
+    </p>
+</section>

--- a/Program.cs
+++ b/Program.cs
@@ -25,7 +25,7 @@ app.UseAuthorization();
 
 app.MapControllerRoute(
     name: "default",
-    pattern: "{controller=Workflow}/{action=Index}/{id?}");
+    pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.MapControllers();
 


### PR DESCRIPTION
## Summary
- add a Home controller and landing page that welcomes users to the orchestration demo
- make the landing page the default route so it appears at the root URL
- highlight workflow features and provide a call-to-action linking to the workflow explorer

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb9fd81508328b9b775c9d8bebef0